### PR TITLE
Add Firebase Messaging and Permissions Handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,6 @@ package-lock.json
 /android/app/global.jks
 /android/app/google-services.json
 /ios/GoogleService-Info.plist
+google-services.json
+GoogleService-Info.plist
+global.jks

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 
     <application
       android:name=".MainApplication"

--- a/firebase.json
+++ b/firebase.json
@@ -6,6 +6,11 @@
     "crashlytics_is_error_generation_on_js_crash_enabled": true,
     "crashlytics_javascript_exception_handler_chaining_enabled": false,
     "android_task_executor_maximum_pool_size": 10,
-    "android_task_executor_keep_alive_seconds": 3
+    "android_task_executor_keep_alive_seconds": 3,
+    "messaging_ios_auto_register_for_remote_messages": true,
+    "messaging_ios_foreground_presentation_options": ["badge", "sound", "list", "banner"],
+    "analytics_auto_collection_enabled": true,
+    "messaging_auto_init_enabled": true,
+    "messaging_android_notification_channel_id": "high-priority"
   }
 }

--- a/ios/InkNest.xcodeproj/project.pbxproj
+++ b/ios/InkNest.xcodeproj/project.pbxproj
@@ -83,6 +83,7 @@
 		922489EA2C133911006F2408 /* Octicons.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = Octicons.ttf; sourceTree = "<group>"; };
 		922489EB2C133911006F2408 /* SimpleLineIcons.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = SimpleLineIcons.ttf; sourceTree = "<group>"; };
 		922489EC2C133911006F2408 /* Zocial.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = Zocial.ttf; sourceTree = "<group>"; };
+		9264CD9E2C26E2BD00345E3A /* InkNest.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = InkNest.entitlements; path = InkNest/InkNest.entitlements; sourceTree = "<group>"; };
 		927EBD5E2C22CCF000AA31BD /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		B262E07B00197153CF8D21F5 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xml; name = PrivacyInfo.xcprivacy; path = InkNest/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		D49F44E471FC706FF39C6A1C /* Pods_InkNest.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_InkNest.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -129,6 +130,7 @@
 		13B07FAE1A68108700A75B9A /* InkNest */ = {
 			isa = PBXGroup;
 			children = (
+				9264CD9E2C26E2BD00345E3A /* InkNest.entitlements */,
 				927EBD5E2C22CCF000AA31BD /* GoogleService-Info.plist */,
 				922489ED2C133911006F2408 /* Fonts */,
 				13B07FAF1A68108700A75B9A /* AppDelegate.h */,
@@ -589,6 +591,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = InkNest/InkNest.entitlements;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = Y425B96UBL;
 				ENABLE_BITCODE = NO;
@@ -617,6 +620,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = InkNest/InkNest.entitlements;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = Y425B96UBL;
 				INFOPLIST_FILE = InkNest/Info.plist;
@@ -721,10 +725,7 @@
 					"-DFOLLY_CFG_NO_COROUTINES=1",
 					"-DFOLLY_HAVE_CLOCK_GETTIME=1",
 				);
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					" ",
-				);
+				OTHER_LDFLAGS = "$(inherited)  ";
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				USE_HERMES = true;
@@ -807,10 +808,7 @@
 					"-DFOLLY_CFG_NO_COROUTINES=1",
 					"-DFOLLY_HAVE_CLOCK_GETTIME=1",
 				);
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					" ",
-				);
+				OTHER_LDFLAGS = "$(inherited)  ";
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				USE_HERMES = true;

--- a/ios/InkNest/Info.plist
+++ b/ios/InkNest/Info.plist
@@ -22,6 +22,8 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSAppTransportSecurity</key>
@@ -55,6 +57,11 @@
 		<string>Zocial.ttf</string>
 		<string>Fontisto.ttf</string>
 	</array>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>fetch</string>
+		<string>remote-notification</string>
+	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>
@@ -72,8 +79,6 @@
 		<string>UIInterfaceOrientationPortrait</string>
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
-	<false/>
-	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 </dict>
 </plist>

--- a/ios/InkNest/InkNest.entitlements
+++ b/ios/InkNest/InkNest.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>aps-environment</key>
+	<string>development</string>
+</dict>
+</plist>

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -22,6 +22,14 @@ PODS:
   - Firebase/Crashlytics (10.27.0):
     - Firebase/CoreOnly
     - FirebaseCrashlytics (~> 10.27.0)
+  - Firebase/Messaging (10.27.0):
+    - Firebase/CoreOnly
+    - FirebaseMessaging (~> 10.27.0)
+  - Firebase/Performance (10.27.0):
+    - Firebase/CoreOnly
+    - FirebasePerformance (~> 10.27.0)
+  - FirebaseABTesting (10.28.0):
+    - FirebaseCore (~> 10.0)
   - FirebaseAnalytics (10.27.0):
     - FirebaseAnalytics/AdIdSupport (= 10.27.0)
     - FirebaseCore (~> 10.0)
@@ -62,6 +70,34 @@ PODS:
     - GoogleUtilities/Environment (~> 7.8)
     - GoogleUtilities/UserDefaults (~> 7.8)
     - PromisesObjC (~> 2.1)
+  - FirebaseMessaging (10.27.0):
+    - FirebaseCore (~> 10.0)
+    - FirebaseInstallations (~> 10.0)
+    - GoogleDataTransport (~> 9.3)
+    - GoogleUtilities/AppDelegateSwizzler (~> 7.8)
+    - GoogleUtilities/Environment (~> 7.8)
+    - GoogleUtilities/Reachability (~> 7.8)
+    - GoogleUtilities/UserDefaults (~> 7.8)
+    - nanopb (< 2.30911.0, >= 2.30908.0)
+  - FirebasePerformance (10.27.0):
+    - FirebaseCore (~> 10.5)
+    - FirebaseInstallations (~> 10.0)
+    - FirebaseRemoteConfig (~> 10.0)
+    - FirebaseSessions (~> 10.5)
+    - GoogleDataTransport (~> 9.2)
+    - GoogleUtilities/Environment (~> 7.13)
+    - GoogleUtilities/ISASwizzler (~> 7.13)
+    - GoogleUtilities/MethodSwizzler (~> 7.13)
+    - GoogleUtilities/UserDefaults (~> 7.13)
+    - nanopb (< 2.30911.0, >= 2.30908.0)
+  - FirebaseRemoteConfig (10.28.0):
+    - FirebaseABTesting (~> 10.0)
+    - FirebaseCore (~> 10.0)
+    - FirebaseInstallations (~> 10.0)
+    - FirebaseRemoteConfigInterop (~> 10.23)
+    - FirebaseSharedSwift (~> 10.0)
+    - GoogleUtilities/Environment (~> 7.8)
+    - "GoogleUtilities/NSData+zlib (~> 7.8)"
   - FirebaseRemoteConfigInterop (10.28.0)
   - FirebaseSessions (10.28.0):
     - FirebaseCore (~> 10.5)
@@ -72,6 +108,7 @@ PODS:
     - GoogleUtilities/UserDefaults (~> 7.13)
     - nanopb (< 2.30911.0, >= 2.30908.0)
     - PromisesSwift (~> 2.1)
+  - FirebaseSharedSwift (10.28.0)
   - fmt (9.1.0)
   - glog (0.3.5)
   - GoogleAppMeasurement (10.27.0):
@@ -106,6 +143,8 @@ PODS:
   - GoogleUtilities/Environment (7.13.3):
     - GoogleUtilities/Privacy
     - PromisesObjC (< 3.0, >= 1.2)
+  - GoogleUtilities/ISASwizzler (7.13.3):
+    - GoogleUtilities/Privacy
   - GoogleUtilities/Logger (7.13.3):
     - GoogleUtilities/Environment
     - GoogleUtilities/Privacy
@@ -1333,6 +1372,15 @@ PODS:
     - FirebaseCoreExtension
     - React-Core
     - RNFBApp
+  - RNFBMessaging (20.1.0):
+    - Firebase/Messaging (= 10.27.0)
+    - FirebaseCoreExtension
+    - React-Core
+    - RNFBApp
+  - RNFBPerf (20.1.0):
+    - Firebase/Performance (= 10.27.0)
+    - React-Core
+    - RNFBApp
   - RNGestureHandler (2.16.2):
     - DoubleConversion
     - glog
@@ -1465,6 +1513,8 @@ DEPENDENCIES:
   - "RNFBAnalytics (from `../node_modules/@react-native-firebase/analytics`)"
   - "RNFBApp (from `../node_modules/@react-native-firebase/app`)"
   - "RNFBCrashlytics (from `../node_modules/@react-native-firebase/crashlytics`)"
+  - "RNFBMessaging (from `../node_modules/@react-native-firebase/messaging`)"
+  - "RNFBPerf (from `../node_modules/@react-native-firebase/perf`)"
   - RNGestureHandler (from `../node_modules/react-native-gesture-handler`)
   - RNReanimated (from `../node_modules/react-native-reanimated`)
   - RNScreens (from `../node_modules/react-native-screens`)
@@ -1473,14 +1523,19 @@ DEPENDENCIES:
 SPEC REPOS:
   trunk:
     - Firebase
+    - FirebaseABTesting
     - FirebaseAnalytics
     - FirebaseCore
     - FirebaseCoreExtension
     - FirebaseCoreInternal
     - FirebaseCrashlytics
     - FirebaseInstallations
+    - FirebaseMessaging
+    - FirebasePerformance
+    - FirebaseRemoteConfig
     - FirebaseRemoteConfigInterop
     - FirebaseSessions
+    - FirebaseSharedSwift
     - GoogleAppMeasurement
     - GoogleDataTransport
     - GoogleUtilities
@@ -1615,6 +1670,10 @@ EXTERNAL SOURCES:
     :path: "../node_modules/@react-native-firebase/app"
   RNFBCrashlytics:
     :path: "../node_modules/@react-native-firebase/crashlytics"
+  RNFBMessaging:
+    :path: "../node_modules/@react-native-firebase/messaging"
+  RNFBPerf:
+    :path: "../node_modules/@react-native-firebase/perf"
   RNGestureHandler:
     :path: "../node_modules/react-native-gesture-handler"
   RNReanimated:
@@ -1631,14 +1690,19 @@ SPEC CHECKSUMS:
   FasterImage: 4563818710bcb2dc2235fab5a5b35c3fb9ac26df
   FBLazyVector: 898d14d17bf19e2435cafd9ea2a1033efe445709
   Firebase: 26b040b20866a55f55eb3611b9fcf3ae64816b86
+  FirebaseABTesting: 589bc28c0ab3e5554336895a34aa262e24276665
   FirebaseAnalytics: f9211b719db260cc91aebee8bb539cb367d0dfd1
   FirebaseCore: a2b95ae4ce7c83ceecfbbbe3b6f1cddc7415a808
   FirebaseCoreExtension: f63147b723e2a700fe0f34ec6fb7f358d6fe83e0
   FirebaseCoreInternal: 58d07f1362fddeb0feb6a857d1d1d1c5e558e698
   FirebaseCrashlytics: 81ea6ec96519388687f6061beb838a8eec482293
   FirebaseInstallations: 60c1d3bc1beef809fd1ad1189a8057a040c59f2e
+  FirebaseMessaging: 585984d0a1df120617eb10b44cad8968b859815e
+  FirebasePerformance: a8f82970bbae75d9b0088696c31246e90e56d30b
+  FirebaseRemoteConfig: f0879a8dccf4e8905716ed849569130efaeab3e2
   FirebaseRemoteConfigInterop: 70d200c6956ef3b5c3592a95e824c1210682d785
   FirebaseSessions: 20da8500ad66bb12622743e170459bf62a0768e8
+  FirebaseSharedSwift: 48de4aec81a6b79bb30404e5e6db43ea74848fed
   fmt: 4c2741a687cc09f0634a2e2c72a838b99f1ff120
   glog: c5d68082e772fa1c511173d6b30a9de2c05a69a2
   GoogleAppMeasurement: f65fc137531af9ad647f1c0a42f3b6a4d3a98049
@@ -1702,6 +1766,8 @@ SPEC CHECKSUMS:
   RNFBAnalytics: 3f336502732e51de9f5a5be8b5e3df879bf2eca7
   RNFBApp: 9acbe359ef3559d6f8ca5c350db471f2b352f98a
   RNFBCrashlytics: a4a66785997e629313ec8005a0811765738239fd
+  RNFBMessaging: b82ef70d252500d3ad104284c0c7f8e1cd22b51e
+  RNFBPerf: fcba70beb746b76c11f05fb17c2446a87ac1ac6f
   RNGestureHandler: 20a4307fd21cbff339abfcfa68192f3f0a6a518b
   RNReanimated: 82d44098f1640ac390d073bca26264d52a67dc7d
   RNScreens: 30249f9331c3b00ae7cb7922e11f58b3ed369c07

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "@react-native-firebase/analytics": "20.1.0",
     "@react-native-firebase/app": "20.1.0",
     "@react-native-firebase/crashlytics": "20.1.0",
+    "@react-native-firebase/messaging": "^20.1.0",
+    "@react-native-firebase/perf": "^20.1.0",
     "@react-navigation/bottom-tabs": "6.5.20",
     "@react-navigation/native": "6.1.17",
     "@react-navigation/native-stack": "6.9.26",

--- a/src/Navigation/index.js
+++ b/src/Navigation/index.js
@@ -1,14 +1,15 @@
-import React, {useLayoutEffect, useRef} from 'react';
+import React, {useEffect, useLayoutEffect, useRef} from 'react';
 import {NavigationContainer} from '@react-navigation/native';
 import {AppNavigation} from './AppNavigation';
 import {navigationRef} from './NavigationService';
-import {Platform, StatusBar} from 'react-native';
+import {PermissionsAndroid, Platform, StatusBar} from 'react-native';
 import {useDispatch, useSelector} from 'react-redux';
 import DownTime from '../Components/UIComp/DownTime';
 import {ClearError} from '../Redux/Reducers';
 import analytics from '@react-native-firebase/analytics';
 import {useNetInfo} from '@react-native-community/netinfo';
 import Network from '../Components/UIComp/Network';
+import messaging from '@react-native-firebase/messaging';
 
 export function RootNavigation() {
   const downTime = useSelector(state => state.data.downTime);
@@ -16,6 +17,32 @@ export function RootNavigation() {
   const {type, isConnected} = useNetInfo();
 
   const routeNameRef = useRef();
+
+  async function requestUserPermission() {
+    const authStatus = await messaging().requestPermission();
+    const enabled =
+      authStatus === messaging.AuthorizationStatus.AUTHORIZED ||
+      authStatus === messaging.AuthorizationStatus.PROVISIONAL;
+
+    if (Platform.OS === 'android') {
+      const PermissionAndroid = PermissionsAndroid.request(
+        PermissionsAndroid.PERMISSIONS.POST_NOTIFICATIONS,
+      );
+      if (PermissionAndroid === PermissionsAndroid.RESULTS.GRANTED) {
+        console.log('Permission Granted');
+      } else {
+        console.log('Permission Denied');
+      }
+    }
+
+    if (enabled) {
+      console.log('Authorization status:', authStatus);
+    }
+  }
+
+  useEffect(() => {
+    requestUserPermission();
+  }, []);
 
   useLayoutEffect(() => {
     if (Platform.OS === 'android') StatusBar.setBackgroundColor('#222');

--- a/yarn.lock
+++ b/yarn.lock
@@ -2530,6 +2530,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@react-native-firebase/messaging@npm:^20.1.0":
+  version: 20.1.0
+  resolution: "@react-native-firebase/messaging@npm:20.1.0"
+  peerDependencies:
+    "@react-native-firebase/app": 20.1.0
+    expo: ">=47.0.0"
+  peerDependenciesMeta:
+    expo:
+      optional: true
+  checksum: 69b114453f093142c39461d05f2637d9dd31e28854f511689192a3a6e069c8aa3739f3eb550ab7600e4d277956fc01361621bde931bd83b7fa86141d20bcb823
+  languageName: node
+  linkType: hard
+
+"@react-native-firebase/perf@npm:^20.1.0":
+  version: 20.1.0
+  resolution: "@react-native-firebase/perf@npm:20.1.0"
+  peerDependencies:
+    "@react-native-firebase/app": 20.1.0
+    expo: ">=47.0.0"
+  peerDependenciesMeta:
+    expo:
+      optional: true
+  checksum: 78394c4b6b087d0613cd21be5b97f9a2485f6170428948e73c187f5f5931ffe6c2cd29d067b3b1b55f4129c6ea9881b201a9217129e1df0a272417c8a66a3c0b
+  languageName: node
+  linkType: hard
+
 "@react-native/assets-registry@npm:0.74.83":
   version: 0.74.83
   resolution: "@react-native/assets-registry@npm:0.74.83"
@@ -3335,6 +3361,8 @@ __metadata:
     "@react-native-firebase/analytics": 20.1.0
     "@react-native-firebase/app": 20.1.0
     "@react-native-firebase/crashlytics": 20.1.0
+    "@react-native-firebase/messaging": ^20.1.0
+    "@react-native-firebase/perf": ^20.1.0
     "@react-native/babel-preset": 0.74.83
     "@react-native/eslint-config": 0.74.83
     "@react-native/metro-config": 0.74.83


### PR DESCRIPTION
The changes introduce Firebase Messaging to the project, including necessary permissions and configurations for both iOS and Android platforms. Key updates include:
- Addition of `InkNest.entitlements` file for iOS to handle push notifications.
- Updates to `Info.plist` to include background modes and non-exempt encryption settings.
- Modifications to `firebase.json` to enable auto-registration for remote messages and other messaging configurations.
- Addition of `@react-native-firebase/messaging` and `@react-native-firebase/perf` dependencies in `package.json`.
- Requesting user permissions for notifications in `RootNavigation` component.
- Adding `POST_NOTIFICATIONS` permission in `AndroidManifest.xml`.
- Adjustments to `.gitignore` to include Firebase configuration files.