### PR TITLE
Refactor reward tracking in ComicDetails component

### DIFF
--- a/src/Redux/Reducers/index.js
+++ b/src/Redux/Reducers/index.js
@@ -12,7 +12,6 @@ const initialState = {
   AnimeWatched: {},
   AnimeBookMarks: {},
   DownloadComic: {},
-  rewardShown: {}, // Track comics that have shown rewards during this session
   scrollPreference: 'horizontal', // Default scroll mode is horizontal
 };
 
@@ -192,14 +191,6 @@ const Reducers = createSlice({
     RemoveAnimeBookMark: (state, action) => {
       delete state.AnimeBookMarks[action?.payload?.url];
     },
-    markRewardShown: (state, action) => {
-      // Mark specific comic as having shown a reward
-      state.rewardShown[action.payload] = true;
-    },
-    resetRewards: (state) => {
-      // Reset all reward tracking (e.g., on app restart)
-      state.rewardShown = {};
-    },
     setScrollPreference: (state, action) => {
       // Update user's preferred comic reading scroll mode
       state.scrollPreference = action.payload;
@@ -226,8 +217,6 @@ export const {
   DownloadComicBook,
   DeleteDownloadedComicBook,
   clearHistory,
-  markRewardShown,
-  resetRewards,
   setScrollPreference,
 } = Reducers.actions;
 export default Reducers.reducer;

--- a/src/Redux/Reducers/index.js
+++ b/src/Redux/Reducers/index.js
@@ -13,6 +13,7 @@ const initialState = {
   AnimeBookMarks: {},
   DownloadComic: {},
   scrollPreference: 'horizontal', // Default scroll mode is horizontal
+  hasRewardAdsShown: false,
 };
 
 /**
@@ -195,6 +196,10 @@ const Reducers = createSlice({
       // Update user's preferred comic reading scroll mode
       state.scrollPreference = action.payload;
     },
+    rewardAdsShown: (state, action) => {
+      // Update the flag indicating whether reward ads have been shown
+      state.hasRewardAdsShown = action.payload;
+    },
   },
 });
 
@@ -218,5 +223,6 @@ export const {
   DeleteDownloadedComicBook,
   clearHistory,
   setScrollPreference,
+  rewardAdsShown,
 } = Reducers.actions;
 export default Reducers.reducer;

--- a/src/Redux/Store/index.js
+++ b/src/Redux/Store/index.js
@@ -6,7 +6,7 @@ import Reducers from '../Reducers';
 const persistConfig = {
   key: 'root',
   storage: storage,
-  blacklist: ['error', 'status', 'loading', 'downTime'],
+  blacklist: ['error', 'status', 'loading', 'downTime', 'hasRewardAdsShown'],
 };
 
 const persistedReducer = persistReducer(persistConfig, Reducers);

--- a/src/Screens/Comic/Details/index.js
+++ b/src/Screens/Comic/Details/index.js
@@ -13,8 +13,6 @@ import ChapterCard from './ChapterCard';
 import HeaderComponent from './Components/HeaderComponent';
 import {AppendAd} from '../../../InkNest-Externals/Ads/AppendAd';
 import PaginationFooter from './Components/FooterPagination';
-import {showRewardedAd} from '../../../InkNest-Externals/Redux/Actions/Download';
-import {markRewardShown} from '../../../Redux/Reducers';
 
 export function ComicDetails({route, navigation}) {
   const [PageLink, setPageLink] = useState(route?.params?.link);
@@ -34,7 +32,6 @@ export function ComicDetails({route, navigation}) {
   const loading = useSelector(state => state.data.loading);
   const error = useSelector(state => state.data.error);
   const ComicDetail = useSelector(state => state.data.dataByUrl[PageLink]);
-  const rewardShown = useSelector(state => state.data.rewardShown);
 
   const reverseChapterList = () => {
     if (getVersion() === forIosValue && forIosLoading === false) {
@@ -70,26 +67,7 @@ export function ComicDetails({route, navigation}) {
     }
   };
 
-  // Check and show reward for first visit
-  useEffect(() => {
-    const showRewardForFirstVisit = async () => {
-      // Only show reward if it hasn't been shown for this comic yet
-      if (PageLink && !rewardShown[PageLink]) {
-        crashlytics().log('Comic Details First Visit Reward Shown');
-        analytics().logEvent('comic_details_first_visit_reward', {
-          pageLink: PageLink,
-        });
 
-        // Show the reward
-        await showRewardedAd();
-
-        // Mark this comic as having shown a reward
-        dispatch(markRewardShown(PageLink));
-      }
-    };
-
-    showRewardForFirstVisit();
-  }, [PageLink, rewardShown]);
 
   useEffect(() => {
     if (getVersion() === forIosValue && forIosLoading === false) {

--- a/src/Screens/Comic/Details/index.js
+++ b/src/Screens/Comic/Details/index.js
@@ -13,6 +13,8 @@ import ChapterCard from './ChapterCard';
 import HeaderComponent from './Components/HeaderComponent';
 import {AppendAd} from '../../../InkNest-Externals/Ads/AppendAd';
 import PaginationFooter from './Components/FooterPagination';
+import {rewardAdsShown} from '../../../Redux/Reducers';
+import {showRewardedAd} from '../../../InkNest-Externals/Redux/Actions/Download';
 
 export function ComicDetails({route, navigation}) {
   const [PageLink, setPageLink] = useState(route?.params?.link);
@@ -32,6 +34,7 @@ export function ComicDetails({route, navigation}) {
   const loading = useSelector(state => state.data.loading);
   const error = useSelector(state => state.data.error);
   const ComicDetail = useSelector(state => state.data.dataByUrl[PageLink]);
+  const hasRewardAdsShown = useSelector(state => state.data.hasRewardAdsShown);
 
   const reverseChapterList = () => {
     if (getVersion() === forIosValue && forIosLoading === false) {
@@ -67,8 +70,18 @@ export function ComicDetails({route, navigation}) {
     }
   };
 
-
-
+  useEffect(() => {
+    (async () => {
+      if (!hasRewardAdsShown) {
+        crashlytics().log('Reward Ads Shown');
+        analytics().logEvent('Reward_Ads_Shown');
+        await showRewardedAd();
+        dispatch(rewardAdsShown(!hasRewardAdsShown));
+      }
+    })();
+  }, [hasRewardAdsShown]);
+  
+  
   useEffect(() => {
     if (getVersion() === forIosValue && forIosLoading === false) {
     } else {


### PR DESCRIPTION
This pull request refactors the reward ad tracking system in the Redux store and updates its usage across the app. The changes simplify the logic by replacing the `rewardShown` object with a single `hasRewardAdsShown` flag, improving readability and maintainability.

### Redux Store Refactoring:

* Replaced the `rewardShown` object with a boolean flag `hasRewardAdsShown` in the Redux store's `initialState` to track whether reward ads have been shown. Removed the associated actions `markRewardShown` and `resetRewards`. Added a new action `rewardAdsShown` to update the flag. (`src/Redux/Reducers/index.js`: [[1]](diffhunk://#diff-afc76b6ba6eea9b430c76616838fa5cd50d6107d240dd8eb6535e6e5111ce692L15-R16) [[2]](diffhunk://#diff-afc76b6ba6eea9b430c76616838fa5cd50d6107d240dd8eb6535e6e5111ce692L195-R202) [[3]](diffhunk://#diff-afc76b6ba6eea9b430c76616838fa5cd50d6107d240dd8eb6535e6e5111ce692L229-R226)
* Updated the Redux store's persist configuration to blacklist `hasRewardAdsShown`, ensuring it does not persist across app sessions. (`src/Redux/Store/index.js`: [src/Redux/Store/index.jsL9-R9](diffhunk://#diff-1f6120b0356b00fa423112c7bc8b057620cd4464842f411941fc37633b97ea4eL9-R9))

### Component Updates:

* Replaced the use of the `rewardShown` object with the `hasRewardAdsShown` flag in the `ComicDetails` component. Simplified the logic for showing reward ads on the first visit by removing comic-specific tracking and using the new flag. (`src/Screens/Comic/Details/index.js`: [[1]](diffhunk://#diff-e069bf712dbb52235a51ccb8e1de526cd01dfac7f78800ee5769b24826039358R16-L17) [[2]](diffhunk://#diff-e069bf712dbb52235a51ccb8e1de526cd01dfac7f78800ee5769b24826039358L37-R37) [[3]](diffhunk://#diff-e069bf712dbb52235a51ccb8e1de526cd01dfac7f78800ee5769b24826039358L73-L92)